### PR TITLE
(fix) Slack invite link

### DIFF
--- a/_posts/2017-12-04-dev-es-2017-como-foi.md
+++ b/_posts/2017-12-04-dev-es-2017-como-foi.md
@@ -16,7 +16,7 @@ Foram mais de 100 que resolveram sair da zona de conforto e aparecer aqui no eve
 
 Os primeiros feedbacks sobre o evento durante o dia já foram super animadores e os pós estão sendo melhores ainda. Isso só motiva a comunidade a continuar mais forte e buscar melhorar ainda mais em 2018.
 
-Se quiserem se envolver mais ainda com a comunidade, entrem no nosso [Slack]() e venham fazer parte da comunidade. Precisamos de mais pessoas colaborando para continuar crescendo.
+Se quiserem se envolver mais ainda com a comunidade, entrem no nosso [Slack](https://devescom.herokuapp.com/) e venham fazer parte da comunidade. Precisamos de mais pessoas colaborando para continuar crescendo.
 
 Os projetos para 2018 já começaram e estão a todo vapor, esse blog é apenas uma das coisas que estão por vir.
 


### PR DESCRIPTION
Fix Slack invite link on post about conf 2017:
![image](https://user-images.githubusercontent.com/413430/33553515-39d8846c-d8e0-11e7-96ee-b390c25e180e.png)

(It's poiting to same page, instead of real invite link)